### PR TITLE
Add NuGet package metadata to LinearSolver.Custom

### DIFF
--- a/LinearSolver.Custom/LinearSolver.Custom.csproj
+++ b/LinearSolver.Custom/LinearSolver.Custom.csproj
@@ -12,6 +12,16 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <!-- NuGet Package Metadata -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>PVS.LinearSolver.Custom</PackageId>
+    <Title>Custom Linear Solver - Goal Programming</Title>
+    <Version>1.0.0</Version>
+    <Authors>PVS</Authors>
+    <Description>Custom goal-based linear solver implementation using preemptive goal programming without external dependencies.</Description>
+    <PackageTags>linear-solver;goal-programming;optimization</PackageTags>
+    <RepositoryUrl>https://github.com/thomasdiemar/RSC</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Resolves #6

This PR adds NuGet package metadata to LinearSolver.Custom/LinearSolver.Custom.csproj to enable package generation and distribution via NuGet.

## Changes
- PackageId: PVS.LinearSolver.Custom
- Title: Custom Linear Solver - Goal Programming
- Version: 1.0.0
- Authors: PVS
- Description: Custom goal-based linear solver implementation using preemptive goal programming without external dependencies.
- Tags: linear-solver;goal-programming;optimization
- Repository URL: https://github.com/thomasdiemar/RSC
- License: MIT

Closes #6