### PR TITLE
Create GitHub Actions workflow for NuGet publishing

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,75 @@
+name: Publish NuGet Packages
+
+on:
+  push:
+    branches:
+      - main
+      - fraction
+    tags:
+      - 'v*'
+
+jobs:
+  build-test-publish:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+    
+    - name: Restore dependencies
+      run: dotnet restore RCS.slnx
+    
+    - name: Build solution (Release)
+      run: dotnet build RCS.slnx -c Release --no-restore
+    
+    - name: Run tests
+      run: dotnet test RCS.Test/RCS.Test.csproj -c Release --no-build --verbosity normal
+    
+    - name: Pack NuGet packages
+      run: |
+        dotnet pack LinearSolver/LinearSolver.csproj -c Release --no-build -o ./nupkg
+        dotnet pack LinearSolver.Custom/LinearSolver.Custom.csproj -c Release --no-build -o ./nupkg
+        dotnet pack RCS/RCS.csproj -c Release --no-build -o ./nupkg
+    
+    - name: Publish to Azure DevOps Feed
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_NUGET_TOKEN }}
+      run: |
+        dotnet nuget add source https://diemar.pkgs.visualstudio.com/06ec9d7b-fe8e-4f72-a28e-3edb09ab1b81/_packaging/SpaceEngineers/nuget/v3/index.json `
+          -n SpaceEngineers `
+          -u diemar `
+          -p $env:NUGET_AUTH_TOKEN `
+          --store-password-in-clear-text
+        
+        foreach ($nupkg in Get-ChildItem ./nupkg -Filter "*.nupkg") {
+          dotnet nuget push $nupkg.FullName `
+            -s SpaceEngineers `
+            --skip-duplicate
+        }
+    
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: ./nupkg
+        retention-days: 30
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: build-test-publish
+    if: always()
+    
+    steps:
+    - name: Publish result
+      run: |
+        if [ "${{ needs.build-test-publish.result }}" = "success" ]; then
+          echo "✅ NuGet packages published successfully"
+        else
+          echo "❌ Publishing failed"
+        fi


### PR DESCRIPTION
Resolves #2

This PR creates a comprehensive GitHub Actions workflow for building, testing, and publishing NuGet packages to the Azure DevOps SpaceEngineers feed.

## Workflow Features
- **Trigger:** Push to main/fraction branches and version tags (v*)
- **Build:** Release configuration
- **Test:** Runs full MSTest suite (84 tests)
- **Package:** Creates NuGet packages for LinearSolver, LinearSolver.Custom, and RCS
- **Publish:** Deploys to Azure DevOps SpaceEngineers feed
- **Authentication:** Uses AZURE_DEVOPS_NUGET_TOKEN secret
- **Artifacts:** Uploads packages for 30 days

## Workflow Steps
1. Checkout code
2. Setup .NET 6.0
3. Restore dependencies
4. Build in Release mode
5. Run MSTest suite
6. Pack NuGet packages
7. Publish to Azure DevOps feed
8. Upload artifacts

## Prerequisites
- GitHub Secret: AZURE_DEVOPS_NUGET_TOKEN (setup in issue #4)
- Azure DevOps feed credentials

Closes #2