### PR TITLE
Create GitHub Actions workflow for NuGet publishing

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -21,6 +21,16 @@ jobs:
       with:
         dotnet-version: '6.0.x'
     
+    - name: Configure NuGet authentication
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_NUGET_TOKEN }}
+      run: |
+        dotnet nuget add source https://diemar.pkgs.visualstudio.com/06ec9d7b-fe8e-4f72-a28e-3edb09ab1b81/_packaging/SpaceEngineers/nuget/v3/index.json `
+          -n SpaceEngineers `
+          -u diemar `
+          -p "$env:NUGET_AUTH_TOKEN" `
+          --store-password-in-clear-text
+    
     - name: Restore dependencies
       run: dotnet restore RCS.slnx
     
@@ -37,15 +47,7 @@ jobs:
         dotnet pack RCS/RCS.csproj -c Release --no-build -o ./nupkg
     
     - name: Publish to Azure DevOps Feed
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_NUGET_TOKEN }}
       run: |
-        dotnet nuget add source https://diemar.pkgs.visualstudio.com/06ec9d7b-fe8e-4f72-a28e-3edb09ab1b81/_packaging/SpaceEngineers/nuget/v3/index.json `
-          -n SpaceEngineers `
-          -u diemar `
-          -p $env:NUGET_AUTH_TOKEN `
-          --store-password-in-clear-text
-        
         foreach ($nupkg in Get-ChildItem ./nupkg -Filter "*.nupkg") {
           dotnet nuget push $nupkg.FullName `
             -s SpaceEngineers `


### PR DESCRIPTION
Resolves #2

This PR creates a comprehensive GitHub Actions workflow for building, testing, and publishing NuGet packages to the Azure DevOps SpaceEngineers feed.

## Workflow Features
- **Trigger:** Push to main/fraction branches and version tags (v*)
- **Build:** Release configuration
- **Test:** Runs full MSTest suite (84 tests)
- **Package:** Creates NuGet packages for LinearSolver, LinearSolver.Custom, and RCS
- **Publish:** Deploys to Azure DevOps SpaceEngineers feed
- **Authentication:** Uses AZURE_DEVOPS_NUGET_TOKEN secret
- **Artifacts:** Uploads packages for 30 days

## Recent Fix
- Fixed NuGet authentication: configure source with credentials BEFORE restore step
- Resolves NU1301 error 'Unable to load the service index'
- Ensures Azure DevOps feed is accessible during dependency restore

## Workflow Steps
1. Checkout code
2. Setup .NET 6.0
3. Configure NuGet authentication
4. Restore dependencies
5. Build in Release mode
6. Run MSTest suite
7. Pack NuGet packages
8. Publish to Azure DevOps feed
9. Upload artifacts

## Prerequisites
- GitHub Secret: AZURE_DEVOPS_NUGET_TOKEN (setup in issue #4)
- Azure DevOps feed credentials

Closes #2