### PR TITLE
Fix: GitHub Actions NuGet source authentication

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -25,13 +25,10 @@ jobs:
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_NUGET_TOKEN }}
       run: |
-        # Try to update existing source, if it doesn't exist this will fail and we'll add it
-        dotnet nuget update source SpaceEngineers `
-          -u diemar `
-          -p "$env:NUGET_AUTH_TOKEN" `
-          --store-password-in-clear-text 2>$null || `
+        # Remove existing source if it exists (ignore errors if not present)
+        dotnet nuget remove source SpaceEngineers 2>$null || $true
         
-        # If update fails, add the source
+        # Add the source with authentication
         dotnet nuget add source https://diemar.pkgs.visualstudio.com/06ec9d7b-fe8e-4f72-a28e-3edb09ab1b81/_packaging/SpaceEngineers/nuget/v3/index.json `
           -n SpaceEngineers `
           -u diemar `


### PR DESCRIPTION
## Issue
GitHub Actions workflow was failing at the 'Configure NuGet authentication' step with error:
'The name specified has already been added to the list of available package sources.'

## Solution
The GitHub Actions runner already has a pre-configured SpaceEngineers source (likely from global config or previous runs). The workflow now explicitly removes the source before adding it with updated credentials.

## Changes
- Modified Configure NuGet authentication step to remove existing source before adding
- Uses 'dotnet nuget remove source' with suppressed errors if source doesn't exist
- Ensures clean slate for NuGet source configuration in each workflow run