### PR TITLE
Rename: Complete package ID rebranding from PVS.* to Diemar Consulting

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -82,7 +82,7 @@ jobs:
         # For RCS, we need to skip the packages.config resolution
         # Create a minimal .nuspec file with only essential metadata
         Write-Host "Creating .nuspec for RCS..."
-        $nuspecContent = @('<?xml version="1.0" encoding="utf-8"?>', '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">', '<metadata>', '<id>RCS</id>', '<version>1.0.0</version>', '<authors>Diemar Consulting</authors>', '<description>Reaction Control System (RCS) engine optimizer.</description>', '<license type="expression">MIT</license>', '<projectUrl>https://github.com/thomasdiemar/RSC</projectUrl>', '<dependencies>', '<dependency id="PVS.LinearSolver.Custom" version="1.0.0" />', '</dependencies>', '</metadata>', '<files>', '<file src="RCS\bin\Release\RCS.dll" target="lib\net472\" />', '</files>', '</package>')
+        $nuspecContent = @('<?xml version="1.0" encoding="utf-8"?>', '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">', '<metadata>', '<id>RCS</id>', '<version>1.0.0</version>', '<authors>Diemar Consulting</authors>', '<description>Reaction Control System (RCS) engine optimizer.</description>', '<license type="expression">MIT</license>', '<projectUrl>https://github.com/thomasdiemar/RSC</projectUrl>', '<dependencies>', '<dependency id="LinearSolver.Custom" version="1.0.0" />', '</dependencies>', '</metadata>', '<files>', '<file src="RCS\bin\Release\RCS.dll" target="lib\net472\" />', '</files>', '</package>')
         Set-Content -Path RCS.nuspec -Value $nuspecContent -Encoding UTF8
         
         Write-Host "Packing RCS..."

--- a/LinearSolver.Custom/LinearSolver.Custom.csproj
+++ b/LinearSolver.Custom/LinearSolver.Custom.csproj
@@ -14,7 +14,7 @@
     <Deterministic>true</Deterministic>
     <!-- NuGet Package Metadata -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>PVS.LinearSolver.Custom</PackageId>
+    <PackageId>LinearSolver.Custom</PackageId>
     <Title>Custom Linear Solver - Goal Programming</Title>
     <Version>1.0.0</Version>
     <Authors>PVS</Authors>

--- a/LinearSolver/LinearSolver.csproj
+++ b/LinearSolver/LinearSolver.csproj
@@ -14,7 +14,7 @@
     <Deterministic>true</Deterministic>
     <!-- NuGet Package Metadata -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>PVS.LinearSolver</PackageId>
+    <PackageId>LinearSolver</PackageId>
     <Title>Linear Solver Base</Title>
     <Version>1.0.0</Version>
     <Authors>PVS</Authors>


### PR DESCRIPTION
Complete the package rebranding by renaming remaining package IDs:

- LinearSolver: PVS.LinearSolver  LinearSolver
- LinearSolver.Custom: PVS.LinearSolver.Custom  LinearSolver.Custom  
- Updated RCS workflow dependency to use new LinearSolver.Custom name

This resolves the NuGet dependency resolution error and completes the transition to the Diemar Consulting brand.