### PR TITLE
Fix NuGet framework compatibility for package installation

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -69,24 +69,22 @@ jobs:
           New-Item -ItemType Directory -Path "./nupkg" | Out-Null
         }
         
-        # Use nuget.exe to pack .NET Framework projects
-        # nuget pack reads metadata from .csproj files
+        # Use .nuspec files to pack .NET Framework projects with explicit framework targeting
+        Write-Host "Installing NuGet CLI..."
+        dotnet tool install -g NuGet.CommandLine --version 6.8.0
+        
         Write-Host "Packing LinearSolver..."
-        nuget pack LinearSolver/LinearSolver.csproj -Properties Configuration=Release -OutputDirectory ./nupkg -IncludeReferencedProjects
+        nuget pack LinearSolver/LinearSolver.nuspec -OutputDirectory ./nupkg
         if ($LASTEXITCODE -ne 0) { throw "LinearSolver pack failed" }
         
         Write-Host "Packing LinearSolver.Custom..."
-        nuget pack LinearSolver.Custom/LinearSolver.Custom.csproj -Properties Configuration=Release -OutputDirectory ./nupkg -IncludeReferencedProjects
+        nuget pack LinearSolver.Custom/LinearSolver.Custom.nuspec -OutputDirectory ./nupkg
         if ($LASTEXITCODE -ne 0) { throw "LinearSolver.Custom pack failed" }
         
         # For RCS, we need to skip the packages.config resolution
-        # Create a minimal .nuspec file with only essential metadata
-        Write-Host "Creating .nuspec for RCS..."
-        $nuspecContent = @('<?xml version="1.0" encoding="utf-8"?>', '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">', '<metadata>', '<id>RCS</id>', '<version>2.0.0</version>', '<authors>Diemar Consulting</authors>', '<description>Reaction Control System (RCS) engine optimizer.</description>', '<license type="expression">MIT</license>', '<projectUrl>https://github.com/thomasdiemar/RSC</projectUrl>', '<dependencies>', '<dependency id="LinearSolver.Custom" version="1.0.0" />', '</dependencies>', '</metadata>', '<files>', '<file src="RCS\bin\Release\RCS.dll" target="lib\net472\" />', '</files>', '</package>')
-        Set-Content -Path RCS.nuspec -Value $nuspecContent -Encoding UTF8
-        
+        # Use the .nuspec file with proper framework targeting
         Write-Host "Packing RCS..."
-        nuget pack RCS.nuspec -OutputDirectory ./nupkg
+        nuget pack RCS/RCS.nuspec -OutputDirectory ./nupkg
         if ($LASTEXITCODE -ne 0) { throw "RCS pack failed" }
         
         # Verify packages were created

--- a/LinearSolver.Custom/LinearSolver.Custom.csproj
+++ b/LinearSolver.Custom/LinearSolver.Custom.csproj
@@ -22,6 +22,9 @@
     <PackageTags>linear-solver;goal-programming;optimization</PackageTags>
     <RepositoryUrl>https://github.com/thomasdiemar/RSC</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetFrameworks></TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/LinearSolver.Custom/LinearSolver.Custom.nuspec
+++ b/LinearSolver.Custom/LinearSolver.Custom.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>LinearSolver.Custom</id>
+    <version>1.0.0</version>
+    <authors>PVS</authors>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/thomasdiemar/RSC</projectUrl>
+    <description>Custom goal-based linear solver implementation using preemptive goal programming without external dependencies.</description>
+    <tags>linear-solver;goal-programming;optimization</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="LinearSolver" version="[1.0.0]" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\LinearSolver.Custom.dll" target="lib\net472\LinearSolver.Custom.dll" />
+    <file src="bin\Release\LinearSolver.Custom.pdb" target="lib\net472\LinearSolver.Custom.pdb" />
+  </files>
+</package>

--- a/LinearSolver/LinearSolver.nuspec
+++ b/LinearSolver/LinearSolver.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>LinearSolver</id>
+    <version>1.0.0</version>
+    <authors>PVS</authors>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/thomasdiemar/RSC</projectUrl>
+    <description>Shared linear solver interfaces and progress primitives.</description>
+    <tags>linear-solver;optimization</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.7.2" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\LinearSolver.dll" target="lib\net472\LinearSolver.dll" />
+    <file src="bin\Release\LinearSolver.pdb" target="lib\net472\LinearSolver.pdb" />
+  </files>
+</package>

--- a/RCS/RCS.nuspec
+++ b/RCS/RCS.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>RCS</id>
+    <version>2.0.0</version>
+    <authors>Diemar Consulting</authors>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/thomasdiemar/RSC</projectUrl>
+    <description>Reaction Control System (RCS) engine optimizer.</description>
+    <tags>reaction-control;optimization;engine</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="LinearSolver.Custom" version="[1.0.0]" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\RCS.dll" target="lib\net472\RCS.dll" />
+    <file src="bin\Release\RCS.pdb" target="lib\net472\RCS.pdb" />
+  </files>
+</package>


### PR DESCRIPTION
## Summary

Resolves the 'Could not install package' error caused by missing framework targeting in NuGet packages.

## Changes

- Created explicit `.nuspec` files with proper `.NETFramework4.7.2` targeting for:
  - `LinearSolver` (1.0.0)
  - `LinearSolver.Custom` (1.0.0)
  - `RCS` (2.0.0)

- Enhanced NuGet metadata in `LinearSolver.Custom.csproj`:
  - Added symbol package support
  - Added explicit include symbols configuration

- Updated publish workflow to:
  - Install NuGet CLI 6.8.0
  - Use `.nuspec` files instead of `.csproj` for packing
  - Ensures consistent framework targeting across all packages

## Technical Details

The previous publish workflow used `nuget pack` on `.csproj` files without explicit framework targeting. This caused NuGet to generate packages with incomplete or incorrect framework declarations. By using explicit `.nuspec` files with `targetFramework=".NETFramework4.7.2"` declarations, packages now properly declare compatibility with .NET Framework 4.7.2 projects.

## Testing

- All core packages build successfully in Release mode
- Package structure verified with proper framework targeting
- Dependencies correctly declared with version constraints
