### PR TITLE
Fix NuGet framework compatibility and implement dynamic versioning

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -59,19 +59,31 @@ jobs:
         }
         $version = $parts[0..3] -join '.'
         
+        # For NuSpec, use only major.minor.build (without revision)
+        $nuspecVersion = $parts[0..2] -join '.'
+        
         Write-Host "Branch: $branchName"
-        Write-Host "Extracted Version: $version"
+        Write-Host "Assembly Version: $version"
+        Write-Host "NuSpec Version: $nuspecVersion"
         
         # Update all AssemblyInfo.cs files
         Get-ChildItem -Recurse -Filter "AssemblyInfo.cs" | Where-Object { $_.FullName -notmatch '(obj|bin)' } | ForEach-Object {
-          Write-Host "Updating: $($_.FullName)"
+          Write-Host "Updating AssemblyInfo: $($_.FullName)"
           $content = Get-Content $_.FullName -Raw -Encoding UTF8
           $content = $content -replace '\[assembly: AssemblyVersion\(".*?"\)\]', "[assembly: AssemblyVersion(`"$version`")]"
           $content = $content -replace '\[assembly: AssemblyFileVersion\(".*?"\)\]', "[assembly: AssemblyFileVersion(`"$version`")]"
           Set-Content -Path $_.FullName -Value $content -Encoding UTF8
         }
         
-        Write-Host "AssemblyVersion update complete!"
+        # Update all .nuspec files
+        Get-ChildItem -Recurse -Filter "*.nuspec" | ForEach-Object {
+          Write-Host "Updating NuSpec: $($_.FullName)"
+          $content = Get-Content $_.FullName -Raw -Encoding UTF8
+          $content = $content -replace '<version>.*?</version>', "<version>$nuspecVersion</version>"
+          Set-Content -Path $_.FullName -Value $content -Encoding UTF8
+        }
+        
+        Write-Host "Assembly and NuSpec version update complete!"
     
     - name: Build solution (Release)
       run: |

--- a/pr_body_nuget_fix.txt
+++ b/pr_body_nuget_fix.txt
@@ -1,9 +1,10 @@
 ## Summary
 
-Resolves the 'Could not install package' error caused by missing framework targeting in NuGet packages.
+Resolves the 'Could not install package' error caused by missing framework targeting in NuGet packages, and implements dynamic assembly versioning from branch names.
 
 ## Changes
 
+### NuGet Framework Compatibility
 - Created explicit `.nuspec` files with proper `.NETFramework4.7.2` targeting for:
   - `LinearSolver` (1.0.0)
   - `LinearSolver.Custom` (1.0.0)
@@ -13,17 +14,50 @@ Resolves the 'Could not install package' error caused by missing framework targe
   - Added symbol package support
   - Added explicit include symbols configuration
 
+### Dynamic Assembly Versioning
 - Updated publish workflow to:
-  - Install NuGet CLI 6.8.0
-  - Use `.nuspec` files instead of `.csproj` for packing
-  - Ensures consistent framework targeting across all packages
+  - Only run on branches starting with `version*` (e.g., `version1.2.3`)
+  - Extract version from branch name
+  - Update all 8 `AssemblyInfo.cs` files before building
+  - Example: `version2.5.1` branch → AssemblyVersion `2.5.1.0`
+
+- Created `Update-AssemblyVersion.ps1` script for local testing:
+  - Can be run locally: `.\Update-AssemblyVersion.ps1 -BranchName "version1.2.3"`
+  - Automatically detects current git branch if no parameter provided
+  - Updates all AssemblyInfo.cs files with proper version format
+
+### Updated Publishing Workflow
+- Install NuGet CLI 6.8.0
+- Use `.nuspec` files instead of `.csproj` for packing
+- Ensures consistent framework targeting across all packages
+- Restricts publication to `version*` branches only
 
 ## Technical Details
 
-The previous publish workflow used `nuget pack` on `.csproj` files without explicit framework targeting. This caused NuGet to generate packages with incomplete or incorrect framework declarations. By using explicit `.nuspec` files with `targetFramework=".NETFramework4.7.2"` declarations, packages now properly declare compatibility with .NET Framework 4.7.2 projects.
+The previous publish workflow:
+- Used `nuget pack` on `.csproj` files without explicit framework targeting
+- Ran on `main` and `fraction` branches
+- Generated packages with incomplete or incorrect framework declarations
+
+Now the workflow:
+- Extracts semantic version from branch name (e.g., `version1.2.3` → `1.2.3.0`)
+- Updates all assembly versions in a dedicated step
+- Uses explicit `.nuspec` files with `targetFramework=".NETFramework4.7.2"` declarations
+- Only runs when pushing to `version*` branches or version tags
 
 ## Testing
 
-- All core packages build successfully in Release mode
-- Package structure verified with proper framework targeting
-- Dependencies correctly declared with version constraints
+Local testing example:
+```powershell
+# Test with version 2.5.3
+.\Update-AssemblyVersion.ps1 -BranchName "version2.5.3"
+# All AssemblyInfo.cs files updated to 2.5.3.0
+
+# Or use current git branch
+.\Update-AssemblyVersion.ps1
+```
+
+Branch naming convention for publishing:
+- `version1.0.0` → Package version 1.0.0.0
+- `version2.1.0` → Package version 2.1.0.0
+- `version1.2` → Package version 1.2.0.0


### PR DESCRIPTION
## Summary

Resolves the 'Could not install package' error caused by missing framework targeting in NuGet packages, implements dynamic assembly versioning from branch names, and fixes package version numbering to match branch versions.

## Changes

### NuGet Framework Compatibility
- Created explicit `.nuspec` files with proper `.NETFramework4.7.2` targeting for:
  - `LinearSolver` (1.0.0)
  - `LinearSolver.Custom` (1.0.0)
  - `RCS` (2.0.0)

- Enhanced NuGet metadata in `LinearSolver.Custom.csproj`:
  - Added symbol package support
  - Added explicit include symbols configuration

### Dynamic Assembly & NuSpec Versioning
- Updated publish workflow to:
  - Only run on branches starting with `version*` (e.g., `version1.2.3`)
  - Extract version from branch name
  - Update all 8 `AssemblyInfo.cs` files before building
  - **Update all `.nuspec` files to match branch version**
  - Example: `version2.5.1` branch → AssemblyVersion `2.5.1.0` AND NuSpec version `2.5.1`

- Created `Update-AssemblyVersion.ps1` script for local testing:
  - Can be run locally: `.\Update-AssemblyVersion.ps1 -BranchName "version1.2.3"`
  - Automatically detects current git branch if no parameter provided
  - Updates all AssemblyInfo.cs files with proper version format

### Updated Publishing Workflow
- Install NuGet CLI 6.8.0
- Use `.nuspec` files instead of `.csproj` for packing
- Ensures consistent framework targeting across all packages
- **Ensures consistent package versioning across all packages**
- Restricts publication to `version*` branches only

## Technical Details

### Previous Issues
- Used `nuget pack` on `.csproj` files without explicit framework targeting
- Generated packages with incomplete or incorrect framework declarations
- Packages were created with versions from hardcoded `.nuspec` files instead of branch name

### Current Solution
- Extracts semantic version from branch name (e.g., `version3.0.0` → Assembly: `3.0.0.0`, NuSpec: `3.0.0`)
- Updates all AssemblyInfo.cs and .nuspec files in dedicated workflow step
- Uses explicit `.nuspec` files with `targetFramework=".NETFramework4.7.2"` declarations
- Only runs when pushing to `version*` branches or version tags

## Testing

Local testing example:
```powershell
# Test with version 2.5.3
.\Update-AssemblyVersion.ps1 -BranchName "version2.5.3"
# All AssemblyInfo.cs files updated to 2.5.3.0

# Or use current git branch
.\Update-AssemblyVersion.ps1
```

Branch naming convention for publishing:
- `version1.0.0` → Package version 1.0.0 (AssemblyVersion 1.0.0.0)
- `version2.1.0` → Package version 2.1.0 (AssemblyVersion 2.1.0.0)
- `version3.0.0` → Package version 3.0.0 (AssemblyVersion 3.0.0.0)

## Fixes Applied

This PR fixes the issue where `version3.0.0` branch created packages with version 1.0.0/2.0.0 instead of 3.0.0. Now all packages will have the correct version matching the branch name.
